### PR TITLE
Refactor account retrieval methods to remove Optional

### DIFF
--- a/src/main/java/info/mackiewicz/bankapp/core/account/repository/AccountRepository.java
+++ b/src/main/java/info/mackiewicz/bankapp/core/account/repository/AccountRepository.java
@@ -14,8 +14,8 @@ import java.util.Optional;
 
 
 public interface AccountRepository extends JpaRepository<Account, Integer> {
-    Optional<List<Account>> findAccountsByOwner_pesel(Pesel ownerPESEL);
-    Optional<List<Account>> findAccountsByOwner_username(String ownerUsername);
+    List<Account> findAccountsByOwner_pesel(Pesel ownerPESEL);
+    List<Account> findAccountsByOwner_username(String ownerUsername);
 
     List<Account> findAccountsByOwner_id(Integer ownerId);
     Optional<Account> findFirstByOwner_email(EmailAddress email);

--- a/src/main/java/info/mackiewicz/bankapp/core/account/service/AccountQueryService.java
+++ b/src/main/java/info/mackiewicz/bankapp/core/account/service/AccountQueryService.java
@@ -51,15 +51,21 @@ class AccountQueryService {
     }
 
     List<Account> getAccountsByOwnersPesel(Pesel pesel) {
-        return accountRepository.findAccountsByOwner_pesel(pesel)
-                .orElseThrow(() -> new OwnerAccountsNotFoundException(
-                        String.format("User with PESEL %s does not have any account.", pesel)));
+        List<Account> accounts = accountRepository.findAccountsByOwner_pesel(pesel);
+        if (accounts.isEmpty()) {
+            throw new OwnerAccountsNotFoundException(
+                    String.format("User with PESEL %s does not have any account.", pesel));
+        }
+        return accounts;
     }
 
     List<Account> getAccountsByOwnersUsername(String username) {
-        return accountRepository.findAccountsByOwner_username(username)
-                .orElseThrow(() -> new OwnerAccountsNotFoundException(
-                        String.format("User with username: %s does not have any account.", username)));
+        List<Account> accounts = accountRepository.findAccountsByOwner_username(username);
+        if (accounts.isEmpty()) {
+            throw new OwnerAccountsNotFoundException(
+                    String.format("User with username: %s does not have any account.", username));
+        }
+        return accounts;
     }
 
     List<Account> getAllAccounts() {

--- a/src/test/java/info/mackiewicz/bankapp/core/account/service/AccountQueryServiceTest.java
+++ b/src/test/java/info/mackiewicz/bankapp/core/account/service/AccountQueryServiceTest.java
@@ -116,7 +116,7 @@ class AccountQueryServiceTest {
         Account testAccount = getTestAccount();
         List<Account> accounts = Collections.singletonList(testAccount);
         when(accountRepository.findAccountsByOwner_pesel(TEST_PESEL))
-            .thenReturn(Optional.of(accounts));
+            .thenReturn(accounts);
 
         // when
         List<Account> result = accountQueryService.getAccountsByOwnersPesel(TEST_PESEL);
@@ -131,7 +131,7 @@ class AccountQueryServiceTest {
     void getAccountsByOwnersPESEL_WhenNoAccountsExist_ShouldThrowException() {
         // given
         when(accountRepository.findAccountsByOwner_pesel(NONEXISTENT_PESEL))
-            .thenReturn(Optional.empty());
+            .thenReturn(Collections.emptyList());
 
         // when & then
         assertThrows(OwnerAccountsNotFoundException.class,
@@ -145,8 +145,7 @@ class AccountQueryServiceTest {
         Account testAccount = getTestAccount();
         List<Account> accounts = Collections.singletonList(testAccount);
         when(accountRepository.findAccountsByOwner_username(TEST_USERNAME))
-            .thenReturn(Optional.of(accounts));
-
+            .thenReturn(accounts);
         // when
         List<Account> result = accountQueryService.getAccountsByOwnersUsername(TEST_USERNAME);
 


### PR DESCRIPTION
Eliminate the use of Optional in account retrieval methods, simplifying the code and handling empty results with exceptions instead. This change enhances clarity and reduces unnecessary complexity in the repository interface.

Closes #63