### PR TITLE
feat: add transaction title validation to `DefaultTransactionValidator`

### DIFF
--- a/src/main/java/info/mackiewicz/bankapp/core/transaction/validation/DefaultTransactionValidator.java
+++ b/src/main/java/info/mackiewicz/bankapp/core/transaction/validation/DefaultTransactionValidator.java
@@ -7,6 +7,7 @@ import info.mackiewicz.bankapp.core.transaction.model.Transaction;
 import info.mackiewicz.bankapp.core.transaction.model.TransactionType;
 import info.mackiewicz.bankapp.core.transaction.model.TransactionTypeCategory;
 import info.mackiewicz.bankapp.core.user.model.User;
+import info.mackiewicz.bankapp.shared.validation.ValidationConstants;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -27,7 +28,14 @@ public class DefaultTransactionValidator implements TransactionValidator {
         validateAccounts(transaction);
         validateSufficientFunds(transaction);
         validateSameOwnerForOwnTransfer(transaction);
+        validateTitle(transaction);
         log.debug("Transaction validation successful");
+    }
+
+    private void validateTitle(Transaction transaction) {
+        if (!transaction.getTitle().matches(ValidationConstants.TRANSFER_TITLE_PATTERN)) {
+            throw new TransactionValidationException("Transaction title contains invalid characters");
+        }
     }
 
     private void validateSufficientFunds(Transaction transaction) {

--- a/src/main/java/info/mackiewicz/bankapp/shared/validation/ValidationConstants.java
+++ b/src/main/java/info/mackiewicz/bankapp/shared/validation/ValidationConstants.java
@@ -36,7 +36,7 @@ public final class ValidationConstants {
     /**
      * A regular expression pattern used to validate the format of a transfer title.
      * This pattern ensures the title consists of letters, digits, and specific
-     * allowable special characters including .,/?@!#&()- as well as spaces.
+     * allowable special characters including .,/?@!%#&()- as well as spaces.
      */
     public static final String TRANSFER_TITLE_PATTERN = "^[\\p{L}0-9.,/?@!%#&()\\-\\s]+$";
 

--- a/src/test/java/info/mackiewicz/bankapp/core/transaction/validation/DefaultTransactionValidatorTest.java
+++ b/src/test/java/info/mackiewicz/bankapp/core/transaction/validation/DefaultTransactionValidatorTest.java
@@ -2,6 +2,7 @@ package info.mackiewicz.bankapp.core.transaction.validation;
 
 import info.mackiewicz.bankapp.core.account.model.Account;
 import info.mackiewicz.bankapp.core.account.model.TestAccountBuilder;
+import info.mackiewicz.bankapp.core.transaction.exception.InsufficientFundsException;
 import info.mackiewicz.bankapp.core.transaction.exception.TransactionAccountConflictException;
 import info.mackiewicz.bankapp.core.transaction.exception.TransactionValidationException;
 import info.mackiewicz.bankapp.core.transaction.model.Transaction;
@@ -37,6 +38,7 @@ class DefaultTransactionValidatorTest {
         transaction.setAmount(BigDecimal.TEN);
         transaction.setSourceAccount(sourceAccount);
         transaction.setDestinationAccount(destinationAccount);
+        transaction.setTitle("Valid Title"); // Properly formatted title
 
         // When & Then
         assertDoesNotThrow(() -> validator.validate(transaction));
@@ -48,6 +50,7 @@ class DefaultTransactionValidatorTest {
         transaction.setType(TransactionType.DEPOSIT);
         transaction.setAmount(BigDecimal.TEN);
         transaction.setDestinationAccount(destinationAccount);
+        transaction.setTitle("Valid Title"); // Properly formatted title
 
         // When & Then
         assertDoesNotThrow(() -> validator.validate(transaction));
@@ -59,6 +62,7 @@ class DefaultTransactionValidatorTest {
         transaction.setType(TransactionType.WITHDRAWAL);
         transaction.setAmount(BigDecimal.TEN);
         transaction.setSourceAccount(sourceAccount);
+        transaction.setTitle("Valid Title"); // Properly formatted title
 
         // When & Then
         assertDoesNotThrow(() -> validator.validate(transaction));
@@ -105,6 +109,48 @@ class DefaultTransactionValidatorTest {
     }
 
     @Test
+    void validate_WithInsufficientFunds_ShouldThrowException() {
+        // Given
+        transaction.setType(TransactionType.WITHDRAWAL);
+        transaction.setAmount(BigDecimal.valueOf(10000));
+        transaction.setSourceAccount(sourceAccount);
+        transaction.setTitle("Valid Title"); // Properly formatted title
+
+        // When & Then
+        assertThrows(InsufficientFundsException.class,
+                () -> validator.validate(transaction),
+                "Insufficient funds for transaction");
+    }
+
+    @Test
+    void validate_WithInvalidTitle_ShouldThrowException() {
+        // Given
+        transaction.setType(TransactionType.TRANSFER_INTERNAL);
+        transaction.setAmount(BigDecimal.TEN);
+        transaction.setSourceAccount(sourceAccount);
+        transaction.setDestinationAccount(destinationAccount);
+        transaction.setTitle("Invalid#<>Title!"); // Contains invalid characters
+
+        // When & Then
+        assertThrows(TransactionValidationException.class,
+                () -> validator.validate(transaction),
+                "Transaction title contains invalid characters");
+    }
+
+    @Test
+    void validate_WithValidTitle_ShouldNotThrowException() {
+        // Given
+        transaction.setType(TransactionType.TRANSFER_INTERNAL);
+        transaction.setAmount(BigDecimal.TEN);
+        transaction.setSourceAccount(sourceAccount);
+        transaction.setDestinationAccount(destinationAccount);
+        transaction.setTitle("Valid Title"); // Properly formatted title
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(transaction));
+    }
+
+    @Test
     void validate_TransferWithNullSourceAccount_ShouldThrowException() {
         // Given
         transaction.setType(TransactionType.TRANSFER_INTERNAL);
@@ -112,7 +158,7 @@ class DefaultTransactionValidatorTest {
         transaction.setDestinationAccount(destinationAccount);
 
         // When & Then
-        assertThrows(TransactionValidationException.class, 
+        assertThrows(TransactionValidationException.class,
             () -> validator.validate(transaction),
             "Transfer transaction must have a source account");
     }
@@ -125,7 +171,7 @@ class DefaultTransactionValidatorTest {
         transaction.setSourceAccount(sourceAccount);
 
         // When & Then
-        assertThrows(TransactionValidationException.class, 
+        assertThrows(TransactionValidationException.class,
             () -> validator.validate(transaction),
             "Transfer transaction must have a destination account");
     }
@@ -139,7 +185,7 @@ class DefaultTransactionValidatorTest {
         transaction.setDestinationAccount(sourceAccount);
 
         // When & Then
-        assertThrows(TransactionAccountConflictException.class, 
+        assertThrows(TransactionAccountConflictException.class,
             () -> validator.validate(transaction),
             "Source and destination accounts cannot be the same");
     }
@@ -158,6 +204,7 @@ class DefaultTransactionValidatorTest {
       
         transaction.setSourceAccount(sourceAccount);
         transaction.setDestinationAccount(destinationAccount);
+        transaction.setTitle("Valid Title"); // Properly formatted title
 
         // When & Then
         assertDoesNotThrow(() -> validator.validate(transaction));
@@ -170,6 +217,7 @@ class DefaultTransactionValidatorTest {
         transaction.setAmount(BigDecimal.TEN);
         transaction.setSourceAccount(sourceAccount);
         transaction.setDestinationAccount(destinationAccount);
+        transaction.setTitle("Valid Title"); // Properly formatted title
 
         // When
         boolean result = validator.isValid(transaction);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added validation to ensure transaction titles only contain allowed characters.
- **Bug Fixes**
	- Updated allowed special characters in transaction titles, replacing the exclamation mark (!) with the percent sign (%).
- **Tests**
	- Enhanced test coverage for transaction title validation and insufficient funds scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->